### PR TITLE
Sort exported map entries in YAML

### DIFF
--- a/Ghidrion/src/main/java/ctrl/TraceFileController.java
+++ b/Ghidrion/src/main/java/ctrl/TraceFileController.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import javax.swing.JFileChooser;
@@ -103,15 +104,15 @@ public class TraceFileController {
 	}
 
 	private static Map<String, Map<String, List<Map<String, String>>>> getHooksMap(MorionTraceFile traceFile) {
-		return traceFile.getHooks()
+		return new TreeSet<>(traceFile.getHooks()) // convert to TreeSet to sort hooks
 				.stream()
 				.collect(
 						Collectors.groupingBy(
 								Hook::getLibraryName,
-								TreeMap::new,
+								TreeMap::new, // sort library names
 								Collectors.groupingBy(
 										Hook::getFunctionName,
-										TreeMap::new,
+										TreeMap::new, // sort function names
 										Collectors.mapping(TraceFileController::hookToMap, Collectors.toList()))));
 	}
 

--- a/Ghidrion/src/main/java/model/Hook.java
+++ b/Ghidrion/src/main/java/model/Hook.java
@@ -55,9 +55,9 @@ public class Hook implements Comparable<Hook> {
 
 	@Override
 	public int compareTo(Hook o) {
-		if (this.libraryName != o.libraryName)
+		if (!this.libraryName.equals(o.libraryName))
 			return this.libraryName.compareTo(o.libraryName);
-		if (this.functionName != o.functionName)
+		if (!this.functionName.equals(o.functionName))
 			return this.functionName.compareTo(o.functionName);
 		return this.entryAddress.compareTo(o.entryAddress);
 	}


### PR DESCRIPTION
Closes #10 

- Uses `SortedMap` (and its implementation `TreeMap`) to sort keys alphabetically
  - Within hooks: libraries
  - Within library: function names
  - Registers
  - Memory entries
- Uses `SortedSet` (and its implementation `TreeSet`) to sort hooks using their comparator within a function
- Does not sort order of hooks/entry state on the top level
- Does not sort order of entry registers/memory on the second level

This fix depends on the library not messing with the order the items are presented to it, but according to my testing it seems to work.